### PR TITLE
Hint

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -16,14 +16,13 @@ default-extensions: NoImplicitPrelude
 dependencies:
   - base == 4.*
   - base-compat >= 0.6.0
-  - directory
   - network
-  - unix
-  - process
   - http-types
   - http-kit >= 0.5
   - bytestring
   - transformers
+  - mtl
+  - hint
 
 executables:
   reserve:

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ dependencies:
   - http-types
   - http-kit >= 0.5
   - bytestring
+  - transformers
 
 executables:
   reserve:

--- a/reserve.cabal
+++ b/reserve.cabal
@@ -31,14 +31,13 @@ executable reserve
   build-depends:
       base == 4.*
     , base-compat >= 0.6.0
-    , directory
     , network
-    , unix
-    , process
     , http-types
     , http-kit >= 0.5
     , bytestring
     , transformers
+    , mtl
+    , hint
   other-modules:
       Interpreter
       Options
@@ -57,14 +56,13 @@ test-suite spec
   build-depends:
       base == 4.*
     , base-compat >= 0.6.0
-    , directory
     , network
-    , unix
-    , process
     , http-types
     , http-kit >= 0.5
     , bytestring
     , transformers
+    , mtl
+    , hint
     , hspec >= 2
     , QuickCheck
     , http-conduit
@@ -73,6 +71,7 @@ test-suite spec
     , mockery
   other-modules:
       Helper
+      InterpreterSpec
       OptionsSpec
       ReserveSpec
       UtilSpec

--- a/reserve.cabal
+++ b/reserve.cabal
@@ -1,9 +1,10 @@
--- This file has been generated from package.yaml by hpack.
+-- This file has been generated from package.yaml by hpack version 0.10.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:             reserve
 version:          0.1.1
+homepage:         https://github.com/sol/reserve#readme
 bug-reports:      https://github.com/sol/reserve/issues
 license:          MIT
 license-file:     LICENSE
@@ -21,13 +22,12 @@ source-repository head
   location: https://github.com/sol/reserve
 
 executable reserve
-  hs-source-dirs: driver, src
   main-is: Main.hs
-  other-modules:
-      Interpreter
-      Options
-      Reserve
-      Util
+  hs-source-dirs:
+      driver
+    , src
+  default-extensions: NoImplicitPrelude
+  ghc-options: -Wall
   build-depends:
       base == 4.*
     , base-compat >= 0.6.0
@@ -38,14 +38,39 @@ executable reserve
     , http-types
     , http-kit >= 0.5
     , bytestring
-  default-extensions: NoImplicitPrelude
-  ghc-options: -Wall
+    , transformers
+  other-modules:
+      Interpreter
+      Options
+      Reserve
+      Util
   default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0
-  hs-source-dirs: test, src
   main-is: Spec.hs
+  hs-source-dirs:
+      test
+    , src
+  default-extensions: NoImplicitPrelude
+  ghc-options: -Wall
+  build-depends:
+      base == 4.*
+    , base-compat >= 0.6.0
+    , directory
+    , network
+    , unix
+    , process
+    , http-types
+    , http-kit >= 0.5
+    , bytestring
+    , transformers
+    , hspec >= 2
+    , QuickCheck
+    , http-conduit
+    , warp >= 3
+    , interpolate
+    , mockery
   other-modules:
       Helper
       OptionsSpec
@@ -55,23 +80,4 @@ test-suite spec
       Options
       Reserve
       Util
-  build-depends:
-      base == 4.*
-    , base-compat >= 0.6.0
-    , directory
-    , network
-    , unix
-    , process
-    , http-types
-    , http-kit >= 0.5
-    , bytestring
-
-    , hspec >= 2
-    , QuickCheck
-    , http-conduit
-    , warp >= 3
-    , interpolate
-    , mockery
-  default-extensions: NoImplicitPrelude
-  ghc-options: -Wall
   default-language: Haskell2010

--- a/src/Reserve.hs
+++ b/src/Reserve.hs
@@ -6,7 +6,6 @@ import           Prelude.Compat
 import           Control.Exception
 import           Control.Monad
 import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Reader
 import           GHC.IO.Exception
 import           System.IO
 
@@ -31,10 +30,9 @@ closeSession (Session h) = sClose h
 
 withSession :: Options -> (Session -> Interpreter.InterpreterM a) -> IO a
 withSession opts action =
-  Interpreter.withInterpreter (optionsMainIs opts) $ do
-    interpreter <- ask
-    liftIO $ bracket (openSession opts) closeSession
-      (\ session -> runReaderT (action session) interpreter)
+  bracket (openSession opts) closeSession $ \ session ->
+    withInterpreter (optionsMainIs opts) $
+      action session
 
 run :: Options -> IO ()
 run opts = withSession opts $ \(Session s) -> forever $ do

--- a/test/InterpreterSpec.hs
+++ b/test/InterpreterSpec.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module InterpreterSpec where
+
+import           Prelude.Compat
+
+import           Data.String.Interpolate
+import           Data.String.Interpolate.Util
+import           Test.Hspec
+import           Test.Mockery.Directory
+
+import           Interpreter
+
+spec :: Spec
+spec = do
+  describe "start" $ do
+    it "allows to pass command line arguments" $ do
+      inTempDirectory $ do
+        writeFile "Main.hs" $ unindent [i|
+          import System.Environment
+          main = getArgs >>= writeFile "args" . show
+        |]
+        withInterpreter "Main.hs" $ do
+          start ["foo"]
+        readFile "args" `shouldReturn` show ["foo"]


### PR DESCRIPTION
This PR switches to using `hint` as a library instead of using `ghci` as a subprocess and communicating with it through its `stdin` and `stdout`.

Pros:
 - The code is cleaner.
 - The test-suite is slightly faster. (3.2 seconds vs. 2.9 on my machine. Well, not much.)

Cons:
  - It will not use the `ghci` on the `$PATH` but the `ghc` `reserve` was compiled with.

The main advantage (and the reason I'm proposing this change) is that this will allow to safely detect compile time errors of the web server that `reserve` tries to run. I tried to make this work by interpreting `stdout` and `stderr` of `ghci`, but it seems impossible to me to get this right. With `hint` it's easily done with `Control.Monad.Catch.catch`.

The feature that I'm planning to build on top of this is to serve the compiler messages to the browser in case of errors.